### PR TITLE
CANS-282 Switch to on demand Jenkins slave node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ def publishLicenseReportHtml() {
     ])
 }
 
-node('cans-slave') {
+node('linux') {
     def artifactoryServer = Artifactory.server artifactoryServerId
     def rtGradle = Artifactory.newGradleBuild()
     properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')), disableConcurrentBuilds(), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],

--- a/jenkinsfile-pull-request.groovy
+++ b/jenkinsfile-pull-request.groovy
@@ -35,7 +35,7 @@ def notifyBuild(String buildStatus, Exception e) {
 }
 
 
-node('cans-slave') {
+node('linux') {
     def serverArti = Artifactory.server 'CWDS_DEV'
     def rtGradle = Artifactory.newGradleBuild()
     properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')), disableConcurrentBuilds(), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],


### PR DESCRIPTION
Just switching this to be able to retire a dedicated Amazon Jenkins slave
https://osi-cwds.atlassian.net/browse/CANS-282

- [ ] I used TDD to develop the feature
- [ ] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests
<!--- Please indicate why tests were not added. -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I ran all my tests locally which were green.
- [ ] My code adds no new issues to Code Climate
- [ ] I ran all the linters and static analyzers for the project (SonarQube, eslint, rubocop, etc).
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.