### PR TITLE
CANS-291: addressing fifth AC to remove filtering of assessments by user id

### DIFF
--- a/src/main/java/gov/ca/cwds/cans/service/AssessmentService.java
+++ b/src/main/java/gov/ca/cwds/cans/service/AssessmentService.java
@@ -52,8 +52,6 @@ public class AssessmentService extends AbstractCrudService<Assessment> {
   }
 
   public Collection<Assessment> search(SearchAssessmentPo searchPo) {
-    final Person currentUser = perryService.getOrPersistAndGetCurrentUser();
-    searchPo.setCreatedById(currentUser.getId());
     return ((AssessmentDao) dao).search(searchPo);
   }
 

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
@@ -257,7 +257,7 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
     final AssessmentDto assessment = readObject(FIXTURE_POST, AssessmentDto.class);
     final List<Object[]> properties = Arrays.asList(
         new Object[]{person, IN_PROGRESS, LocalDate.of(2010, 1, 1), AUTHORIZED_ACCOUNT_FIXTURE},
-        new Object[]{person, IN_PROGRESS, LocalDate.of(2015, 10, 10), AUTHORIZED_ACCOUNT_FIXTURE},
+        new Object[]{person, IN_PROGRESS, LocalDate.of(2015, 10, 10), AUTHORIZED_EL_DORADO_ACCOUNT_FIXTURE},
         // out of search results because of the other person
         new Object[]{otherPerson, IN_PROGRESS, LocalDate.of(2015, 10, 10),
             AUTHORIZED_ACCOUNT_FIXTURE},

--- a/src/test/resources/fixtures/perry-account/el-dorado-all-authorized.json
+++ b/src/test/resources/fixtures/perry-account/el-dorado-all-authorized.json
@@ -1,6 +1,6 @@
 {
-  "user": "000 supervisor",
-  "staffId": "000",
+  "user": "001 supervisor",
+  "staffId": "001",
   "roles": [
     "Supervisor",
     "CANS-worker"


### PR DESCRIPTION
https://osi-cwds.atlassian.net/browse/CANS-291

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. Include JIRA link -->
Remove filtering of assessments by user id from AssessmentService

## Tests
- [x] I used TDD to develop the feature
- [x] I have included unit tests
- [x] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters and static analyzers for the project (SonarQube, eslint, rubocop, etc).
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.

