### PR TITLE
CANS-795: Delete Assessment - v1.1 Business Rules

### DIFF
--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AbstractFunctionalTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AbstractFunctionalTest.java
@@ -117,6 +117,15 @@ public abstract class AbstractFunctionalTest {
         .post(Entity.entity(assessment, MediaType.APPLICATION_JSON_TYPE));
   }
 
+  Response deleteAssessmentAndGetResponse(AssessmentDto assessment, String userFixture)
+      throws IOException {
+    return clientTestRule
+        .withSecurityToken(userFixture)
+        .target(ASSESSMENTS + SLASH + assessment.getId())
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .delete();
+  }
+
   Response putAssessmentAndGetResponse(AssessmentDto assessment, String userFixture)
       throws IOException {
     return clientTestRule

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceAuthorizationTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceAuthorizationTest.java
@@ -5,6 +5,7 @@ import static gov.ca.cwds.cans.Constants.API.SECURITY;
 
 import gov.ca.cwds.cans.domain.dto.assessment.AssessmentDto;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
@@ -15,8 +16,22 @@ public class AssessmentResourceAuthorizationTest extends AbstractFunctionalTest 
   public void postAssessment_success_whenUserHasAssignment() throws Exception {
     postAssessmentAndCheckStatus(
         "fixtures/client-of-0Ki-rw-assignment.json",
-        "fixtures/perry-account/0ki-napa-none.json",
+        "fixtures/perry-account/0ki-napa-all.json",
         HttpStatus.SC_CREATED);
+  }
+
+  @Test
+  public void deleteAssessment_unauthorized_whenUserHasAssignmentButDoesntHaveDeletePerm()
+      throws Exception {
+    AssessmentDto assessment = createAssessmentDto("fixtures/client-of-0Ki-rw-assignment.json");
+    assessment =
+        postAssessmentAndGetResponse(assessment, "fixtures/perry-account/0ki-napa-all.json")
+            .readEntity(AssessmentDto.class);
+    Response response =
+        deleteAssessmentAndGetResponse(
+            assessment, "fixtures/perry-account/0ki-napa-all-except-delete.json");
+    Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatus());
+    pushToCleanUpStack(assessment.getId(), "fixtures/perry-account/0ki-napa-all.json");
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
@@ -235,6 +235,20 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
     assertThat(actualResults[1].getId(), is(assessmentIds.get(0)));
     assertThat(actualResults[2].getId(), is(assessmentIds.get(4)));
     assertThat(actualResults[3].getId(), is(assessmentIds.get(3)));
+
+    // check allowed operations
+
+    // first two are in progress, so "complete" permission is present
+    for (int i = 0; i < 2; i++) {
+      AssessmentMetaDto metaDto = actualResults[i];
+      checkOperations(metaDto, "read", "update", "create", "complete", "write", "delete");
+    }
+
+    // next two are completed so "complete" permission is absent
+    for (int i = 2; i < 4; i++) {
+      AssessmentMetaDto metaDto = actualResults[i];
+      checkOperations(metaDto, "read", "update", "create", "write", "delete");
+    }
   }
 
   @Test

--- a/src/test/resources/fixtures/perry-account/0ki-napa-all-except-delete.json
+++ b/src/test/resources/fixtures/perry-account/0ki-napa-all-except-delete.json
@@ -1,0 +1,26 @@
+{
+  "user": "RACFID1",
+  "staffId": "0Ki",
+  "roles": [
+    "Supervisor",
+    "CANS-worker"
+  ],
+  "county_code": "28",
+  "county_name": "Napa",
+  "county_cws_code": "1095",
+  "privileges": [
+    "CWS CANS System",
+    "CANS-rollout",
+    "CANS-staff-person-subordinates-read",
+    "CANS-staff-person-read",
+    "CANS-staff-person-clients-read",
+    "CANS-client-read",
+    "CANS-client-search",
+    "CANS-assessment-read",
+    "CANS-assessment-create",
+    "CANS-assessment-in-progress-update",
+    "CANS-assessment-completed-update",
+    "CANS-assessment-complete",
+    "CANS-rollout"
+  ]
+}


### PR DESCRIPTION
## Description
Delete authz tests are added, operations population for list of assessments is implemented(will be required for future implementations of disabling "delete" button in assessment's "kabob").

## Tests
- [x] I used TDD to develop the feature
- [x] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters and static analyzers for the project (SonarQube, eslint, rubocop, etc).
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.

