### PR TITLE
CANS-875: Client county determination logic updated to have one county

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ project.ext {
     mainClass = 'gov.ca.cwds.cans.CansApplication'
     projectMajorVersion = '0.10.4'
     dataModelVersion = '0.10.3_708-RC'
-    coreApiVersion = '1.10.3_894-RC'
+    coreApiVersion = '1.11.0_905-RC'
     apiSecurityVersion = '4.0.0_1010-RC'
     dropwizardVersion = '1.1.0'
     hibernateVersion = '5.2.16.Final'

--- a/src/main/java/gov/ca/cwds/cans/security/ClientReadAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/cans/security/ClientReadAuthorizer.java
@@ -58,7 +58,7 @@ public class ClientReadAuthorizer extends ClientResultReadAuthorizer {
   private boolean checkClientResultAccess(String clientId) {
     boolean isClientResultAuthorized = super.checkId(clientId);
     LOG.info(
-        "Authorization: client [{}] abstract authorization result [{}]",
+        "Authorization: client [{}] result authorization result [{}]",
         clientId,
         isClientResultAuthorized);
     return isClientResultAuthorized;

--- a/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
+++ b/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
@@ -2,7 +2,9 @@ package gov.ca.cwds.cans.security;
 
 import com.google.inject.Provider;
 import gov.ca.cwds.cans.domain.dto.Dto;
+import gov.ca.cwds.rest.exception.ExpectedException;
 import java.util.Set;
+import javax.ws.rs.core.Response.Status;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -19,6 +21,10 @@ public class PermissionInterceptor implements MethodInterceptor {
   @Override
   public Object invoke(MethodInvocation toDto) throws Throwable {
     Dto dto = (Dto) toDto.proceed();
+    if (dto == null) {
+      throw new ExpectedException(
+          "Assessment was not found in database or has no person object", Status.NOT_FOUND);
+    }
     Set<String> allowedOperations =
         permissionServiceProvider.get().getAllowedOperations(toDto.getArguments()[0]);
     dto.addMetadata(OPERATIONS_METADATA_KEY, allowedOperations);

--- a/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
+++ b/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
@@ -23,7 +23,7 @@ public class PermissionInterceptor implements MethodInterceptor {
     Dto dto = (Dto) toDto.proceed();
     if (dto == null) {
       throw new ExpectedException(
-          "Assessment was not found in database or has no person object", Status.NOT_FOUND);
+          "Assessment was not found in the database", Status.NOT_FOUND);
     }
     Set<String> allowedOperations =
         permissionServiceProvider.get().getAllowedOperations(toDto.getArguments()[0]);

--- a/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
+++ b/src/main/java/gov/ca/cwds/cans/security/PermissionInterceptor.java
@@ -22,8 +22,7 @@ public class PermissionInterceptor implements MethodInterceptor {
   public Object invoke(MethodInvocation toDto) throws Throwable {
     Dto dto = (Dto) toDto.proceed();
     if (dto == null) {
-      throw new ExpectedException(
-          "Assessment was not found in the database", Status.NOT_FOUND);
+      throw new ExpectedException("Assessment was not found in the database", Status.NOT_FOUND);
     }
     Set<String> allowedOperations =
         permissionServiceProvider.get().getAllowedOperations(toDto.getArguments()[0]);

--- a/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
@@ -39,7 +39,8 @@ public abstract class AssessmentAccessAuthorizer extends BaseAuthorizer<Assessme
     if (assessment == null
         || assessment.getPerson() == null
         || assessment.getPerson().getExternalId() == null) {
-      throw new ExpectedException("Assessment not found or have no person", Status.NOT_FOUND);
+      throw new ExpectedException(
+          "Assessment was not found in database or has no person object", Status.NOT_FOUND);
     }
     String clientId = assessment.getPerson().getExternalId();
     return checkClientAbstractAccess(clientId)

--- a/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
@@ -5,8 +5,10 @@ import gov.ca.cwds.cans.dao.AssessmentDao;
 import gov.ca.cwds.cans.domain.entity.Assessment;
 import gov.ca.cwds.cans.security.ClientReadAuthorizer;
 import gov.ca.cwds.data.legacy.cms.entity.enums.AccessType;
+import gov.ca.cwds.rest.exception.ExpectedException;
 import gov.ca.cwds.security.authorizer.BaseAuthorizer;
 import gov.ca.cwds.security.utils.PrincipalUtils;
+import javax.ws.rs.core.Response.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +36,11 @@ public abstract class AssessmentAccessAuthorizer extends BaseAuthorizer<Assessme
 
   @Override
   protected boolean checkInstance(Assessment assessment) {
+    if (assessment == null
+        || assessment.getPerson() == null
+        || assessment.getPerson().getExternalId() == null) {
+      throw new ExpectedException("Assessment not found or have no person", Status.NOT_FOUND);
+    }
     String clientId = assessment.getPerson().getExternalId();
     return checkClientAbstractAccess(clientId)
         || checkByAssignment(clientId)

--- a/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentAccessAuthorizer.java
@@ -40,7 +40,7 @@ public abstract class AssessmentAccessAuthorizer extends BaseAuthorizer<Assessme
         || assessment.getPerson() == null
         || assessment.getPerson().getExternalId() == null) {
       throw new ExpectedException(
-          "Assessment was not found in database or has no person object", Status.NOT_FOUND);
+          "Assessment was not found in the database or has no person object", Status.NOT_FOUND);
     }
     String clientId = assessment.getPerson().getExternalId();
     return checkClientAbstractAccess(clientId)

--- a/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentOperationAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/cans/security/assessment/AssessmentOperationAuthorizer.java
@@ -29,16 +29,17 @@ public abstract class AssessmentOperationAuthorizer extends AssessmentAccessAuth
         new AssessmentOperationFact(
             operation, assessment, PrincipalUtils.getPrincipal(), isAssessmentAccessible);
     boolean result = rulesService.authorize(operationFact);
-    if (!result) {
-      LOG.info(
-          "Authorization: operation [{}] for assessment with status [{}] and county [{}]"
-              + " is not allowed for user [{}] from county [{}]",
-          operationFact.getOperation(),
-          assessment.getStatus(),
-          assessment.getPerson().getCounty(),
-          operationFact.getUser().getStaffId(),
-          operationFact.getUser().getCountyCwsCode());
-    }
+    LOG.info(
+        "Authorization: client [{}], operation [{}] for assessment [{}] with status [{}] and county [{}]"
+            + " for user [{}] from county [{}] with result [{}]",
+        assessment.getPerson().getExternalId(),
+        operationFact.getOperation(),
+        assessment.getId(),
+        assessment.getStatus(),
+        assessment.getPerson().getCounty(),
+        operationFact.getUser().getStaffId(),
+        operationFact.getUser().getCountyCwsCode(),
+        result);
     return result;
   }
 }

--- a/src/main/java/gov/ca/cwds/cans/validation/PersistentAware.java
+++ b/src/main/java/gov/ca/cwds/cans/validation/PersistentAware.java
@@ -9,9 +9,15 @@ import org.hibernate.SessionFactory;
 public interface PersistentAware<T extends Persistent> {
   default T getPersisted(SessionFactory sessionFactory, Class<T> clazz, Serializable primaryKey) {
     Session session = sessionFactory.openSession();
-    T entity = session.get(clazz, primaryKey);
-    session.detach(entity);
-    session.close();
+    T entity;
+    try {
+      entity = session.get(clazz, primaryKey);
+      if (entity != null) {
+        session.detach(entity);
+      }
+    } finally {
+      session.close();
+    }
     return entity;
   }
 }

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
@@ -370,6 +370,47 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
     assertThat(response.getStatus(), is(HttpStatus.SC_UNPROCESSABLE_ENTITY));
   }
 
+  @Test
+  public void getAssessment_success_whenExistingCans() throws IOException {
+    // given
+    final ClientDto person = readObject(FIXTURE_PERSON, ClientDto.class);
+    final AssessmentDto assessment = readObject(FIXTURE_POST, AssessmentDto.class);
+    AssessmentDto postedAssessment =
+        postAssessment(
+            assessment,
+            person,
+            AssessmentStatus.IN_PROGRESS,
+            LocalDate.now(),
+            AUTHORIZED_NAPA_ACCOUNT_FIXTURE);
+    pushToCleanUpStack(postedAssessment.getId(), AUTHORIZED_NAPA_ACCOUNT_FIXTURE);
+    // when
+    Response response =
+        clientTestRule
+            .withSecurityToken(AUTHORIZED_NAPA_ACCOUNT_FIXTURE)
+            .target(ASSESSMENTS + SLASH + postedAssessment.getId())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get();
+
+    // then
+    assertThat(response.getStatus(), is(HttpStatus.SC_OK));
+  }
+
+  @Test
+  public void getAssessment_notFound_whenNonExistingCans() throws IOException {
+    // given
+    final String assessmentId = "1234567890";
+    // when
+    Response response =
+        clientTestRule
+            .withSecurityToken(AUTHORIZED_NAPA_ACCOUNT_FIXTURE)
+            .target(ASSESSMENTS + SLASH + assessmentId)
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get();
+
+    // then
+    assertThat(response.getStatus(), is(HttpStatus.SC_NOT_FOUND));
+  }
+
   private AssessmentDto postAssessment(
       AssessmentDto assessment,
       ClientDto person,

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/AssessmentResourceTest.java
@@ -233,8 +233,7 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
       checkOperations(metaDto, "read", "update", "create", "write", "delete");
     }
 
-
-    //Delete one for otherPerson
+    // Delete one for otherPerson
     final AssessmentMetaDto deleteResults =
         clientTestRule
             .withSecurityToken(AUTHORIZED_NAPA_ACCOUNT_FIXTURE)
@@ -243,11 +242,12 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
             .delete()
             .readEntity(AssessmentMetaDto.class);
     assertThat(deleteResults.getStatus(), is(AssessmentStatus.DELETED));
-    //Check for DELETED to come back in results
+    // Check for DELETED to come back in results
     // when
     final Entity<SearchAssessmentRequest> searchRequestIncludeDeleted =
         Entity.entity(
-            new SearchAssessmentRequest().setClientIdentifier(otherPerson.getIdentifier())
+            new SearchAssessmentRequest()
+                .setClientIdentifier(otherPerson.getIdentifier())
                 .setIncludeDeleted(Boolean.TRUE),
             MediaType.APPLICATION_JSON_TYPE);
     final AssessmentMetaDto[] actualResults2 =
@@ -261,7 +261,6 @@ public class AssessmentResourceTest extends AbstractFunctionalTest {
     // then
     assertThat(actualResults2.length, is(1));
     assertThat(actualResults2[0].getId(), is(assessmentIds.get(2)));
-
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/ClientsResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/ClientsResourceTest.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.cans.rest.resource;
 
+import static org.hamcrest.Matchers.equalTo;
+
 import gov.ca.cwds.cans.Constants.API;
 import gov.ca.cwds.cans.domain.dto.person.ClientDto;
 import gov.ca.cwds.cans.domain.enumeration.ServiceSource;
@@ -8,7 +10,6 @@ import java.io.IOException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,8 +35,9 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
             .target(API.CLIENTS + SLASH + CLIENT_NAPA_SENSITIVE_CMS_ID)
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get();
-    Assert.assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.SC_OK));
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
     ClientDto clientDto = response.readEntity(ClientDto.class);
+    Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1095"));
     checkOperations(clientDto, "read");
   }
 
@@ -47,13 +49,14 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
             .target(API.CLIENTS + SLASH + CLIENT_CMS_ID)
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get();
-    Assert.assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.SC_OK));
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
 
     ClientDto clientDto = response.readEntity(ClientDto.class);
     Assert.assertEquals(CLIENT_CMS_BASE10_KEY, clientDto.getExternalId());
     Assert.assertEquals(CASE_OR_REFERRAL_CMS_ID, clientDto.getServiceSourceId());
     Assert.assertEquals(CASE_OR_REFERRAL_CMS_BASE10_KEY, clientDto.getServiceSourceUiId());
     Assert.assertEquals(ServiceSource.CASE, clientDto.getServiceSource());
+    Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1126"));
   }
 
   @Test
@@ -64,10 +67,11 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
             .target(API.CLIENTS + SLASH + CLIENT_CMS_ID)
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get();
-    Assert.assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.SC_OK));
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
 
     ClientDto clientDto = response.readEntity(ClientDto.class);
     checkOperations(clientDto, "read", "createAssessment", "completeAssessment");
+    Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1126"));
   }
 
   @Test
@@ -79,7 +83,7 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
             .target(API.CLIENTS + "/" + expected.getIdentifier())
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get();
-    Assert.assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.SC_FORBIDDEN));
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_FORBIDDEN));
   }
 
   @Test
@@ -90,6 +94,6 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
             .target(API.CLIENTS + SLASH + "-1")
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get();
-    Assert.assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.SC_NOT_FOUND));
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
   }
 }

--- a/src/test/java/gov/ca/cwds/cans/rest/resource/ClientsResourceTest.java
+++ b/src/test/java/gov/ca/cwds/cans/rest/resource/ClientsResourceTest.java
@@ -38,6 +38,7 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
     Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
     ClientDto clientDto = response.readEntity(ClientDto.class);
     Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1095"));
+    Assert.assertThat(clientDto.getCounty().getExternalId(), equalTo("1095"));
     checkOperations(clientDto, "read");
   }
 
@@ -57,6 +58,7 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
     Assert.assertEquals(CASE_OR_REFERRAL_CMS_BASE10_KEY, clientDto.getServiceSourceUiId());
     Assert.assertEquals(ServiceSource.CASE, clientDto.getServiceSource());
     Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1126"));
+    Assert.assertThat(clientDto.getCounty().getExternalId(), equalTo("1126"));
   }
 
   @Test
@@ -72,6 +74,22 @@ public class ClientsResourceTest extends AbstractFunctionalTest {
     ClientDto clientDto = response.readEntity(ClientDto.class);
     checkOperations(clientDto, "read", "createAssessment", "completeAssessment");
     Assert.assertThat(clientDto.getCounties().get(0).getExternalId(), equalTo("1126"));
+    Assert.assertThat(clientDto.getCounty().getExternalId(), equalTo("1126"));
+  }
+
+  @Test
+  public void doGetClient_success_whenNoCounty() throws IOException {
+    Response response =
+        clientTestRule
+            .withSecurityToken(AUTHORIZED_ACCOUNT)
+            .target(API.CLIENTS + SLASH + "AbtnmWU0Mq")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get();
+    Assert.assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
+
+    ClientDto clientDto = response.readEntity(ClientDto.class);
+    Assert.assertTrue(clientDto.getCounties().isEmpty());
+    Assert.assertNull(clientDto.getCounty());
   }
 
   @Test

--- a/src/test/resources/fixtures/perry-account/0ki-napa-none.json
+++ b/src/test/resources/fixtures/perry-account/0ki-napa-none.json
@@ -10,6 +10,7 @@
   "county_cws_code": "1095",
   "privileges": [
     "CWS CANS System",
+    "CWS Case Management System",
     "CANS-rollout",
     "CANS-staff-person-subordinates-read",
     "CANS-staff-person-read",


### PR DESCRIPTION
## JIRA
https://osi-cwds.atlassian.net/browse/CANS-875

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. Include JIRA link -->
The new version of API Core added which provided new DAO method retrieve Client County. Now Client will have just one county or no county determined from operational CWS/CMS DB2 database.

## Tests
- [ ] I used TDD to develop the feature
- [ ] I have included unit tests
- [x] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters and static analyzers for the project (SonarQube, eslint, rubocop, etc).
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.

