### PR TITLE
Fix master jenkins job

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -230,7 +230,7 @@ node('linux') {
         }
         stage('Deploy to Pre-int') {
           withCredentials([usernameColonPassword(credentialsId: 'fa186416-faac-44c0-a2fa-089aed50ca17', variable: 'jenkinsauth')]) {
-          sh "curl -u $  'http://jenkins.mgmt.cwds.io:8080/job/PreInt-Integration/job/deploy-cans-api/buildWithParameters?token=deployCansApiToPreint&version=${newTag}'"
+            sh "curl -u $jenkinsauth 'http://jenkins.mgmt.cwds.io:8080/job/PreInt-Integration/job/deploy-cans-api/buildWithParameters?token=deployCansApiToPreint&version=${newTag}'"
           }
         }
         stage('Update Pre-int Manifest') {


### PR DESCRIPTION
## Description
The master build jenkins job is failing with:
```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 233: illegal string body character after dollar sign;
   solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 233, column 11.
             sh "curl -u $  'http://jenkins.mgmt.cwds.io:8080/job/PreInt-Integration/job/deploy-cans-api/buildWithParameters?token=deployCansApiToPreint&version=${newTag}'"
```

Trying to fix it

## Tests
- [ ] I used TDD to develop the feature
- [ ] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I ran all my tests locally which were green.
- [ ] My code adds no new issues to Code Climate
- [ ] I ran all the linters and static analyzers for the project (SonarQube, eslint, rubocop, etc).
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
