### PR TITLE
FIT-292 update to build.gradle to ensure new semver used if passed in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ project.ext {
     projectDockerGroup = 'cwds'
     projectDockerAppName = 'cans-api'
     mainClass = 'gov.ca.cwds.cans.CansApplication'
-    projectMajorVersion = '0.11.2'
+    semanticVersion = System.getProperty('newVersion')
+    projectMajorVersion = (semanticVersion && semanticVersion != '') ? semanticVersion : '0.11.2'
     dataModelVersion = '0.11.2_711-RC'
     coreApiVersion = '1.11.2_908-RC'
     apiSecurityVersion = '4.0.0_1010-RC'

--- a/build.gradle
+++ b/build.gradle
@@ -63,13 +63,6 @@ project.ext {
 
 group projectGroup
 
-if (System.getProperty('newVersion') && System.getProperty('newVersion')!='null') {
-      def newVersion = "${System.getProperty('newVersion')}"
-      version = newVersion
-    } else {
-      version = projectVersion
-}
-
 repositories {
     mavenLocal()
     maven {


### PR DESCRIPTION
## JIRA
https://osi-cwds.atlassian.net/browse/FIT-292

Sorry for the 2nd PR on this...difficult to test much of this until it actually makes it to the master build. Last PR didn't correctly use the new semantic version created and was still using projectMajorVersion set in build.gradle. This PR rectifies that.